### PR TITLE
feat: add Huya live platform integration

### DIFF
--- a/src/external/live/huya/client.rs
+++ b/src/external/live/huya/client.rs
@@ -1,0 +1,217 @@
+use super::types::{MpApiResponse, MpData};
+use crate::error::{AppError, AppResult};
+use crate::external::client::HTTP_CLIENT;
+use crate::external::live::platform::LivePlatform;
+use crate::external::live::provider::LivePlatformProvider;
+use crate::external::live::types::{AnchorInfo, LiveStatus, RoomInfo, RoomStatusInfo};
+use async_trait::async_trait;
+use std::collections::HashMap;
+
+const MP_API: &str = "https://mp.huya.com/cache.php";
+
+pub struct HuyaLive;
+
+impl HuyaLive {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn make_error(message: impl Into<String>, source: Option<anyhow::Error>) -> AppError {
+        AppError::ExternalApi {
+            platform: "huya".into(),
+            message: message.into(),
+            source,
+        }
+    }
+
+    fn parse_live_status(data: &MpData) -> LiveStatus {
+        let is_live = data.real_live_status.as_deref() == Some("ON")
+            && data.live_status.as_deref() == Some("ON");
+        let is_replay = data.live_data.introduction.starts_with("【回放】");
+
+        if is_replay {
+            LiveStatus::Replay
+        } else if is_live {
+            LiveStatus::Live
+        } else {
+            LiveStatus::Offline
+        }
+    }
+
+    async fn fetch_mp_data(&self, room_id: &str) -> AppResult<MpData> {
+        let url = format!(
+            "{}?do=profileRoom&m=Live&roomid={}&showSecret=1",
+            MP_API, room_id
+        );
+
+        let resp = HTTP_CLIENT
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| Self::make_error(format!("request failed: {}", e), Some(e.into())))?
+            .error_for_status()
+            .map_err(|e| Self::make_error(format!("HTTP error: {}", e), Some(e.into())))?;
+
+        let api_resp: MpApiResponse = resp
+            .json()
+            .await
+            .map_err(|e| Self::make_error(format!("invalid JSON: {}", e), Some(e.into())))?;
+
+        if api_resp.status != 200 {
+            return Err(Self::make_error(
+                format!("API error: {}", api_resp.message),
+                None,
+            ));
+        }
+
+        api_resp
+            .data
+            .ok_or_else(|| Self::make_error("no data in response", None))
+    }
+}
+
+impl Default for HuyaLive {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl LivePlatformProvider for HuyaLive {
+    fn platform(&self) -> LivePlatform {
+        LivePlatform::Huya
+    }
+
+    async fn get_room_info(&self, room_id: &str) -> AppResult<RoomInfo> {
+        let data = self.fetch_mp_data(room_id).await?;
+
+        Ok(RoomInfo {
+            room_id: data
+                .profile_info
+                .profile_room
+                .clone()
+                .unwrap_or_else(|| room_id.to_string()),
+            uid: data.profile_info.uid.to_string(),
+            title: data.live_data.introduction.clone(),
+            live_status: Self::parse_live_status(&data),
+            online: data.live_data.user_count.unwrap_or(0),
+            cover_url: Some(data.live_data.screenshot),
+            area_name: data.live_data.game_full_name,
+        })
+    }
+
+    async fn get_anchor_info(&self, uid: &str) -> AppResult<AnchorInfo> {
+        let data = self.fetch_mp_data(uid).await?;
+
+        Ok(AnchorInfo {
+            uid: data.profile_info.uid.to_string(),
+            name: data.profile_info.nick,
+            avatar_url: Some(data.profile_info.avatar180),
+            follower_count: data.profile_info.activity_count,
+            room_id: data.profile_info.profile_room,
+        })
+    }
+
+    async fn get_rooms_status_by_uids(
+        &self,
+        uids: &[&str],
+    ) -> AppResult<HashMap<String, RoomStatusInfo>> {
+        let mut result = HashMap::new();
+
+        for uid in uids {
+            match self.fetch_mp_data(uid).await {
+                Ok(data) => {
+                    let info = RoomStatusInfo {
+                        uid: data.profile_info.uid.to_string(),
+                        room_id: data
+                            .profile_info
+                            .profile_room
+                            .clone()
+                            .unwrap_or_else(|| uid.to_string()),
+                        title: data.live_data.introduction.clone(),
+                        live_status: Self::parse_live_status(&data),
+                        online: data.live_data.user_count.unwrap_or(0),
+                        uname: data.profile_info.nick,
+                        face: Some(data.profile_info.avatar180),
+                        cover_url: Some(data.live_data.screenshot),
+                        area_name: data.live_data.game_full_name,
+                    };
+                    result.insert(uid.to_string(), info);
+                }
+                Err(_) => continue,
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_platform_returns_huya() {
+        let client = HuyaLive::new();
+        assert_eq!(client.platform(), LivePlatform::Huya);
+    }
+
+    #[test]
+    fn test_default_impl() {
+        let _client: HuyaLive = Default::default();
+    }
+
+    #[test]
+    fn test_make_error_without_source() {
+        let err = HuyaLive::make_error("test error", None);
+        match err {
+            AppError::ExternalApi {
+                platform,
+                message,
+                source,
+            } => {
+                assert_eq!(platform, "huya");
+                assert_eq!(message, "test error");
+                assert!(source.is_none());
+            }
+            _ => panic!("Expected ExternalApi error"),
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn test_get_room_info_real_api() {
+        let client = HuyaLive::new();
+        let result = client.get_room_info("660000").await;
+        if let Err(e) = &result {
+            eprintln!("Error: {}", e);
+        }
+        assert!(result.is_ok());
+        let room = result.unwrap();
+        assert!(!room.room_id.is_empty());
+        assert!(!room.title.is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn test_get_anchor_info_real_api() {
+        let client = HuyaLive::new();
+        let result = client.get_anchor_info("660000").await;
+        if let Err(e) = &result {
+            eprintln!("Error: {}", e);
+        }
+        assert!(result.is_ok());
+        let anchor = result.unwrap();
+        assert!(!anchor.name.is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn test_get_rooms_status_by_uids_real_api() {
+        let client = HuyaLive::new();
+        let result = client.get_rooms_status_by_uids(&["660000", "600000"]).await;
+        assert!(result.is_ok());
+        let map = result.unwrap();
+        assert!(!map.is_empty());
+    }
+}

--- a/src/external/live/huya/mod.rs
+++ b/src/external/live/huya/mod.rs
@@ -1,0 +1,4 @@
+mod client;
+mod types;
+
+pub use client::HuyaLive;

--- a/src/external/live/huya/types.rs
+++ b/src/external/live/huya/types.rs
@@ -1,0 +1,83 @@
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub(super) struct MpApiResponse {
+    pub status: i32,
+    pub message: String,
+    #[serde(default)]
+    pub data: Option<MpData>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct MpData {
+    #[serde(rename = "realLiveStatus")]
+    pub real_live_status: Option<String>,
+    #[serde(rename = "liveStatus")]
+    pub live_status: Option<String>,
+    #[serde(rename = "profileInfo")]
+    pub profile_info: ProfileInfo,
+    #[serde(rename = "liveData")]
+    pub live_data: LiveData,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct ProfileInfo {
+    #[serde(deserialize_with = "deserialize_uid")]
+    pub uid: i64,
+    pub nick: String,
+    pub avatar180: String,
+    #[serde(
+        rename = "profileRoom",
+        default,
+        deserialize_with = "deserialize_optional_room_id"
+    )]
+    pub profile_room: Option<String>,
+    #[serde(rename = "activityCount", default)]
+    pub activity_count: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct LiveData {
+    pub introduction: String,
+    pub screenshot: String,
+    #[serde(rename = "gameFullName", default)]
+    pub game_full_name: Option<String>,
+    #[serde(rename = "userCount", default)]
+    pub user_count: Option<u64>,
+}
+
+fn deserialize_uid<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error;
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum UidValue {
+        Int(i64),
+        Str(String),
+    }
+
+    match UidValue::deserialize(deserializer)? {
+        UidValue::Int(i) => Ok(i),
+        UidValue::Str(s) => s.parse().map_err(D::Error::custom),
+    }
+}
+
+fn deserialize_optional_room_id<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum RoomIdValue {
+        Int(i64),
+        Str(String),
+    }
+
+    match Option::<RoomIdValue>::deserialize(deserializer)? {
+        Some(RoomIdValue::Int(i)) => Ok(Some(i.to_string())),
+        Some(RoomIdValue::Str(s)) => Ok(Some(s)),
+        None => Ok(None),
+    }
+}

--- a/src/external/live/mod.rs
+++ b/src/external/live/mod.rs
@@ -1,6 +1,7 @@
 mod bilibili;
 mod douyin;
 mod douyu;
+mod huya;
 mod platform;
 mod provider;
 mod types;
@@ -8,6 +9,7 @@ mod types;
 pub use bilibili::BilibiliLive;
 pub use douyin::DouyinLive;
 pub use douyu::DouyuLive;
+pub use huya::HuyaLive;
 pub use platform::LivePlatform;
 pub use provider::LivePlatformProvider;
 pub use types::{AnchorInfo, LiveStatus, RoomInfo, RoomStatusInfo};
@@ -17,11 +19,13 @@ use std::sync::LazyLock;
 static BILIBILI: LazyLock<BilibiliLive> = LazyLock::new(BilibiliLive::new);
 static DOUYIN: LazyLock<DouyinLive> = LazyLock::new(DouyinLive::new);
 static DOUYU: LazyLock<DouyuLive> = LazyLock::new(DouyuLive::new);
+static HUYA: LazyLock<HuyaLive> = LazyLock::new(HuyaLive::new);
 
 pub fn get_provider(platform: LivePlatform) -> &'static dyn LivePlatformProvider {
     match platform {
         LivePlatform::Bilibili => &*BILIBILI,
         LivePlatform::Douyin => &*DOUYIN,
         LivePlatform::Douyu => &*DOUYU,
+        LivePlatform::Huya => &*HUYA,
     }
 }

--- a/src/external/live/platform.rs
+++ b/src/external/live/platform.rs
@@ -9,6 +9,7 @@ pub enum LivePlatform {
     Bilibili,
     Douyin,
     Douyu,
+    Huya,
 }
 
 impl fmt::Display for LivePlatform {
@@ -17,6 +18,7 @@ impl fmt::Display for LivePlatform {
             LivePlatform::Bilibili => write!(f, "bilibili"),
             LivePlatform::Douyin => write!(f, "douyin"),
             LivePlatform::Douyu => write!(f, "douyu"),
+            LivePlatform::Huya => write!(f, "huya"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add Huya live platform integration using MP API
- Implement `LivePlatformProvider` trait for HuyaLive client
- Support room info, anchor info, and batch status queries
- Map API fields: `profileRoom` → room_id, `gameFullName` → area_name, `userCount` → online, `activityCount` → follower_count
- Detect live status and replay streams

## Test plan
- [x] Unit tests pass (3/3)
- [x] Network tests with real Huya room IDs pass (3/3)
- [x] Clippy linter passes with no warnings
- [x] Code builds successfully
- [x] Pre-commit hooks pass